### PR TITLE
Updated for Swift 2 and enabled size classes

### DIFF
--- a/Swifteroid/Swifteroid.xcodeproj/project.pbxproj
+++ b/Swifteroid/Swifteroid.xcodeproj/project.pbxproj
@@ -165,7 +165,7 @@
 				TargetAttributes = {
 					4CCD55AF1B27159F0068FFE9 = {
 						CreatedOnToolsVersion = 6.3.2;
-						DevelopmentTeam = 2DT937228U;
+						DevelopmentTeam = 6E5RVX7ELK;
 					};
 					4CCD55C41B27159F0068FFE9 = {
 						CreatedOnToolsVersion = 6.3.2;
@@ -341,14 +341,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
 				INFOPLIST_FILE = Swifteroid/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "me.pirogoff.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
 			};
 			name = Debug;
 		};
@@ -358,14 +356,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
 				INFOPLIST_FILE = Swifteroid/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "me.pirogoff.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
 			};
 			name = Release;
 		};

--- a/Swifteroid/Swifteroid.xcodeproj/project.pbxproj
+++ b/Swifteroid/Swifteroid.xcodeproj/project.pbxproj
@@ -165,7 +165,7 @@
 				TargetAttributes = {
 					4CCD55AF1B27159F0068FFE9 = {
 						CreatedOnToolsVersion = 6.3.2;
-						DevelopmentTeam = 6E5RVX7ELK;
+						DevelopmentTeam = 2DT937228U;
 					};
 					4CCD55C41B27159F0068FFE9 = {
 						CreatedOnToolsVersion = 6.3.2;
@@ -341,12 +341,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
 				INFOPLIST_FILE = Swifteroid/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "me.pirogoff.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 			};
 			name = Debug;
 		};
@@ -356,12 +358,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = YES;
 				INFOPLIST_FILE = Swifteroid/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "me.pirogoff.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 			};
 			name = Release;
 		};

--- a/Swifteroid/Swifteroid/Base.lproj/Main.storyboard
+++ b/Swifteroid/Swifteroid/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8121.17" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8101.14"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <customFonts key="customFonts">
         <mutableArray key="ionicons.ttf">
@@ -20,26 +21,26 @@
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mQP-Wo-sOB">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <color key="backgroundColor" red="0.86216862409999995" green="0.90890216089999998" blue="0.98206792190000003" alpha="1" colorSpace="calibratedRGB"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7Yc-g4-zan" customClass="UIImageView">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vSp-JX-GF0">
-                                <rect key="frame" x="0.0" y="506" width="320" height="62"/>
+                                <rect key="frame" x="0.0" y="538" width="600" height="62"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="p30-pq-SkN">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="62"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="62"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nZi-aT-mZN">
-                                            <rect key="frame" x="138" y="7" width="44" height="47"/>
+                                            <rect key="frame" x="278" y="7" width="44" height="47"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="47" id="Ntc-iH-Q0g"/>
                                                 <constraint firstAttribute="width" constant="44" id="TLY-4n-e8e"/>
@@ -55,7 +56,7 @@
                                             </connections>
                                         </button>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JUc-3u-5Bd">
-                                            <rect key="frame" x="282" y="13" width="30" height="35"/>
+                                            <rect key="frame" x="562" y="13" width="30" height="35"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="30" id="HkT-ih-blT"/>
                                                 <constraint firstAttribute="height" constant="35" id="sow-zv-uhH"/>
@@ -100,7 +101,7 @@
                                 <blurEffect style="light"/>
                             </visualEffectView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gr0-tE-fjl">
-                                <rect key="frame" x="0.0" y="8" width="320" height="17"/>
+                                <rect key="frame" x="0.0" y="8" width="600" height="17"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="17" id="v5f-Pf-Gu1"/>
                                 </constraints>
@@ -139,7 +140,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="300" y="499"/>
+            <point key="canvasLocation" x="562.5" y="527.11267605633805"/>
         </scene>
     </scenes>
 </document>

--- a/Swifteroid/Swifteroid/SwifteroidController.swift
+++ b/Swifteroid/Swifteroid/SwifteroidController.swift
@@ -75,8 +75,7 @@ class SwifteroidController {
                 if error == nil {
                     let imageData = AVCaptureStillImageOutput.jpegStillImageNSDataRepresentation(sampleBuffer)
                     
-                    let metadata:NSDictionary = CMCopyDictionaryOfAttachments(nil, sampleBuffer, CMAttachmentMode(kCMAttachmentMode_ShouldPropagate))!.takeUnretainedValue()
-                    
+                    let metadata:NSDictionary = CMCopyDictionaryOfAttachments(nil, sampleBuffer, CMAttachmentMode(kCMAttachmentMode_ShouldPropagate))!                    
                     if let image = UIImage(data: imageData) {
                         dispatch_async(dispatch_get_main_queue()) { () -> Void in
                             handler(image: image, metadata:metadata)

--- a/Swifteroid/Swifteroid/ViewController.swift
+++ b/Swifteroid/Swifteroid/ViewController.swift
@@ -41,9 +41,8 @@ class ViewController: UIViewController {
     @IBAction func savePreviewPhoto(sender: AnyObject) {
         if let image = lastPhoto {
             savePreviewdPhoto(image)
-            print("", appendNewline: false)
         } else {
-            print("No Phot to Save! \n", appendNewline: false)
+            print("No photo to save!")
         }
         clearPreview()
         lastPhoto = nil


### PR DESCRIPTION
Would not build in Swift 2 so fixed print statements and takeUnretainedValue(). I can't tell from the documentation if metadata should be unowned, but when I make it unowned the app crashes.

Camera view was misplaced on iPhone 6s so size classes are now enabled and it should be placed correctly.
